### PR TITLE
build: check version during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,15 @@ jobs:
         run: |
           echo -n "$SONATYPE_PGP_SECRET" | base64 --decode | gpg --batch --import
 
+      - name: Check version
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Detected version: $VERSION"
+          if [ "$VERSION" = "0.0.0" ]; then
+            echo "ERROR: version resolved to 0.0.0 — the tag must follow the format v<major>.<minor>.<patch> (e.g. v9.10.0)"
+            exit 1
+          fi
+
       - name: Deploy
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-`mvn clean deploy`
+# gatling-asm-shaded
+
+[ASM](https://asm.ow2.io/) repackaged (shaded) under the `io.gatling.internal.asm` namespace for internal use by Gatling.
+
+## Build
+
+```
+mvn clean package
+```
+
+## Release
+
+Releases are triggered by pushing a git tag. The tag format **must use 3 version parts** to be picked up correctly by `maven-git-versioning-extension`:
+
+```
+git tag v9.10.0
+git push origin v9.10.0
+```
+
+A tag like `v9.10` (2 parts) will **not** be recognized and the release will fail with version `0.0.0`.
+
+The release workflow signs the artifacts and publishes them to Maven Central automatically.


### PR DESCRIPTION
Motivation:
Fomerly, we used to push vX.Y version (2 parts) and the former plugin automatically deploy a vX.Y.0 artifacts to maven central. The new plugin configuration doesn't read tags that do not contain 3 digital parts

Modifications:
 * Document the release process to hint about 3 parts version
 * Check if the plugin find a correct version during release workflow

Result:
Less error and more hints